### PR TITLE
Green always passes

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -79,8 +79,11 @@ class TestWishlist(unittest.TestCase):
         """It should List all Wishlists in the database"""
         wishlists = Wishlist.all()
         self.assertEqual(wishlists, [])
+        i = 0
         for wishlist in WishlistFactory.create_batch(5):
+            wishlist.wishlist_name = f"wishlist-x-{i}"
             wishlist.create()
+            i = i + 1
         # Assert that there are now 5 wishlists in the database
         wishlists = Wishlist.all()
         self.assertEqual(len(wishlists), 5)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -57,8 +57,9 @@ class TestWishlistServer(TestCase):
     def _create_wishlists(self, count):
         """Factory method to create accounts in bulk"""
         wishlists = []
-        for _ in range(count):
+        for i in range(count):
             wishlist = WishlistFactory()
+            wishlist.wishlist_name = f"wishlist-x-{i}"
             resp = self.client.post(BASE_URL, json=wishlist.serialize())
             self.assertEqual(
                 resp.status_code,


### PR DESCRIPTION
Previously, green would fail probabilistically. That was because creating a batch of Wishlists would lead to name conflicts. Now, the names are explicitly set after creation. Hence, there green will always pass.

No more "CI Build Failed"!!!